### PR TITLE
Wait for timeout and reject execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Wait for timeout and reject execution
+
 ## [0.0.3][] - 2021-10-26
 
 - Add default values for `init(options)`

--- a/noroutine.js
+++ b/noroutine.js
@@ -50,13 +50,17 @@ const monitoring = () => {
 const invoke = async (method, args) => {
   const id = balancer.id++;
   return new Promise((resolve, reject) => {
-    balancer.tasks.set(id, { resolve, reject });
+    const timer = setTimeout(() => {
+      reject(new Error(`Timeout execution for method '${method}'`));
+    }, balancer.options.timeout);
+    balancer.tasks.set(id, { resolve, reject, timer });
     balancer.current.postMessage({ id, method, args });
   });
 };
 
 const workerResults = ({ id, error, result }) => {
   const task = balancer.tasks.get(id);
+  clearTimeout(task.timer);
   balancer.tasks.delete(id);
   if (error) task.reject(error);
   else task.resolve(result);

--- a/test/module1.js
+++ b/test/module1.js
@@ -8,4 +8,10 @@ const method1 = async (value) => {
   return null;
 };
 
-module.exports = { method1 };
+const method2 = async (value) => {
+  await metautil.delay(5500);
+  if (value) return { key: value };
+  return null;
+};
+
+module.exports = { method1, method2 };

--- a/test/noroutine.js
+++ b/test/noroutine.js
@@ -30,3 +30,12 @@ metatests.test('Noroutine execute method', async (test) => {
   test.end();
   await noroutine.finalize();
 });
+
+metatests.test('Wait for timeout and reject execution', async (test) => {
+  try {
+    await module1.method2('value1');
+    test.strictSame(true, false);
+  } catch (e) {
+    test.strictSame(e instanceof Error, true);
+  }
+});


### PR DESCRIPTION
Closes: https://github.com/metarhia/noroutine/issues/3

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
