### PR TITLE
Use second argument of .then instead of .catch

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -7,11 +7,8 @@ const target = names.reduce((o, name) => ({ ...o, ...require(name) }), {});
 
 parentPort.on('message', (message) => {
   const method = target[message.method];
-  method(...message.args)
-    .then((result) => {
-      parentPort.postMessage({ id: message.id, result });
-    })
-    .catch((error) => {
-      parentPort.postMessage({ id: message.id, error });
-    });
+  method(...message.args).then(
+    (result) => void parentPort.postMessage({ id: message.id, result }),
+    (error) => void parentPort.postMessage({ id: message.id, error }),
+  );
 });


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
